### PR TITLE
Add release automation with goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    permissions:
+        contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.x'
+    - name: Build and release
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,2 @@
+builds:
+- skip: true


### PR DESCRIPTION
In this case all this does is create the actual release entry and its associated changelog, since we're not building any binaries. ssrfgen doesn't have any use beyond this project so for now there's no prepackaged build of it.