### PR TITLE
CI: Switch gotestfmt back to v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,12 +32,12 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Setup gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2.1.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Setup gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Go module caching
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
The v2 branch on the gotestfmt action has been updated and should no longer result in warnings being logged about Node 12.