### PR TITLE
Updated prefixes by ssrfgen

### DIFF
--- a/ssrf_gen.go
+++ b/ssrf_gen.go
@@ -70,5 +70,6 @@ var (
 		netip.MustParsePrefix("2001:db8::/32"),     // Documentation (RFC 3849)
 		netip.MustParsePrefix("2002::/16"),         // 6to4 (RFC 3056)
 		netip.MustParsePrefix("2620:4f:8000::/48"), // Direct Delegation AS112 Service (RFC 7534)
+		netip.MustParsePrefix("3fff::/20"),         // Documentation (RFC 9637)
 	}
 )


### PR DESCRIPTION
Include `3fff::/20` because for some reason the IETF keeps allocating things in the global unicast IPv6 range that shouldn't be globally reachable.